### PR TITLE
[2022.10.18] update user recentPC 구현 완료

### DIFF
--- a/routes/controllers/user.controller.js
+++ b/routes/controllers/user.controller.js
@@ -14,3 +14,24 @@ exports.getRecentPc = async (req, res, next) => {
 
   res.json({ recentPc: user.pc });
 };
+
+exports.updateRecentPc = async (req, res, next) => {
+  const userId = req.params.users_id;
+  const recentPc = req.body.recentPc;
+
+  const user = await User.findOne({ email: userId });
+
+  await User.updateOne(
+    { email: userId },
+    {
+      name: user.name,
+      email: user.email,
+      gesture: user.gesture,
+      pc: {
+        name: recentPc.name,
+        ipAddress: recentPc.ip,
+        lastAccessData: new Date(),
+      },
+    },
+  );
+};

--- a/routes/user.js
+++ b/routes/user.js
@@ -6,6 +6,8 @@ const {
 } = require("./controllers/user.controller");
 const router = express.Router();
 
-router.route("/:users_id/gestures").get(getGesture).post(updateRecentPc);
+router.get("/:users_id/gestures", getGesture);
+
+router.route("/:users_id/pc").get(getRecentPc).post(updateRecentPc);
 
 module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,9 +1,11 @@
 const express = require("express");
-const { getRecentPc, getGesture } = require("./controllers/user.controller");
+const {
+  getRecentPc,
+  getGesture,
+  updateRecentPc,
+} = require("./controllers/user.controller");
 const router = express.Router();
 
-router.get("/:users_id/gestures", getGesture);
-
-router.get("/:users_id/pc", getRecentPc);
+router.route("/:users_id/gestures").get(getGesture).post(updateRecentPc);
 
 module.exports = router;


### PR DESCRIPTION
# Topic
- update user recentPC 구현 완료.

# Detail
- 클라이언트에서 post 요청을 보내면 서버에서 Database에 있는 user의 최근 접속한 PC의 데이터를 갱신.

# Kanban Link
https://www.notion.so/vanillacoding/POST-users-user_id-pc-max-1-by-conncted_at-order-asc-706e30d22bb74ce9889348fbe4ee0a20

# Kanban List
- [x]  클라이언트에서 Select PC페이지에서 선택 시 서버에 해당 PC의 이름, IP address, 접속 날짜를 req.body에 담아서 요청
- [x]  서버는 요청을 받아 해당 유저의 최근 접속 PC 데이터를 req.body의 데이터를 이용해 변경한 뒤 클라이언트에게 success or failure로 응답
- [x]  클라이언트는 응답 형식에 따라 사용자에게 저장되었을 경우 아무 알림도 띄우지 않고, 실패했을 경우 실패 알림을 띄워줌

# ETC
- 해당사항 없음