### PR TITLE
[2022.10.19] post email 구현 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "google-auth-library": "^8.5.2",
         "http-errors": "~1.6.3",
         "mongoose": "^6.6.5",
-        "morgan": "~1.9.1"
+        "morgan": "~1.9.1",
+        "nodemailer": "^6.8.0"
       },
       "devDependencies": {
         "nodemon": "^2.0.20"
@@ -1062,6 +1063,14 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.8.0.tgz",
+      "integrity": "sha512-EjYvSmHzekz6VNkNd12aUqAco+bOkRe3Of5jVhltqKhEsjw/y0PYPJfp83+s9Wzh1dspYAkUW/YNQ350NATbSQ==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -2276,6 +2285,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+    },
+    "nodemailer": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.8.0.tgz",
+      "integrity": "sha512-EjYvSmHzekz6VNkNd12aUqAco+bOkRe3Of5jVhltqKhEsjw/y0PYPJfp83+s9Wzh1dspYAkUW/YNQ350NATbSQ=="
     },
     "nodemon": {
       "version": "2.0.20",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "google-auth-library": "^8.5.2",
     "http-errors": "~1.6.3",
     "mongoose": "^6.6.5",
-    "morgan": "~1.9.1"
+    "morgan": "~1.9.1",
+    "nodemailer": "^6.8.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.20"

--- a/routes/controllers/user.controller.js
+++ b/routes/controllers/user.controller.js
@@ -1,10 +1,11 @@
 const User = require("../../models/User");
+const nodemailer = require("nodemailer");
 
 exports.getGesture = async (req, res, next) => {
   const userId = req.params.users_id;
   const user = await User.findOne({ email: userId });
 
-  res.send({ gesture: user.gesture });
+  res.json({ gesture: user.gesture });
 };
 
 exports.getRecentPc = async (req, res, next) => {
@@ -34,4 +35,41 @@ exports.updateRecentPc = async (req, res, next) => {
       },
     },
   );
+};
+
+exports.postEmail = async (req, res, next) => {
+  try {
+    const transporter = nodemailer.createTransport({
+      host: "smtp.gmail.com",
+      port: 465,
+      auth: {
+        user: process.env.MAILS_EMAIL,
+        pass: process.env.MAILS_PWD,
+      },
+      secure: true,
+    });
+    const email = req.body.email;
+    const htmlContent = `
+      <h1>Hello User!</h1>
+      <p>
+        <h2>아래의 링크를 통해 다운로드 받을 수 있습니다. (차후 다운로드 링크로 변경할 예정)</h2>
+        <h3>https://github.com/Team-Saisiot/portable-trackpad-package<h3>
+      </p>
+    `;
+    const mailOption = {
+      from: process.env.MAILS_EMAIL,
+      to: email,
+      subject: "Portable Trackpad Desktop Application Download",
+      html: htmlContent,
+    };
+
+    await transporter.sendMail(mailOption);
+
+    res.json({ result: "success" });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({
+      message: "Send email failed, Please try again.",
+    });
+  }
 };

--- a/routes/user.js
+++ b/routes/user.js
@@ -3,6 +3,7 @@ const {
   getRecentPc,
   getGesture,
   updateRecentPc,
+  postEmail,
 } = require("./controllers/user.controller");
 const router = express.Router();
 
@@ -10,4 +11,5 @@ router.get("/:users_id/gestures", getGesture);
 
 router.route("/:users_id/pc").get(getRecentPc).post(updateRecentPc);
 
+router.post("/email", postEmail);
 module.exports = router;


### PR DESCRIPTION
# Topic
- post email 구현 완료.

# Detail
- 클라이언트에서 email 보내기 버튼을 눌러서 post를 요청하면 서버에서 클라이언트의 이메일로 패키지를 다운로드할 수 있는 링크를 담은 이메일 전송
- 기존에는 클라이언트단에서만 구현하려 했으나, react native에서 백그라운드를 통해 이메일을 보내는 기능을 지원하지 않아서 서버에서 이메일을 보내는 기능으로 변경

# Kanban Link
https://www.notion.so/vanillacoding/Layout-559e61b2dd4e4dc99833294742cb0519

# Kanban List
- [x]  사용자가 Email input에 주소를 입력하면 해당하는 Email 주소로 Package파일을 다운로드 받을 수 있는 구글 드라이브 링크를 보내준다.
- [x]  Next버튼을 누르면 네트워크 안내 페이지로 이동한다.

# ETC
- 해당사항 없음